### PR TITLE
Fix class name for PHP7 compatibility

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/BoolField.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/BoolField.php
@@ -23,7 +23,7 @@ namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
  * @Annotation
  * @deprecated This class will be removed in ODM 2.0
  */
-final class String extends AbstractField
+final class BoolField extends AbstractField
 {
-    public $type = 'string';
+    public $type = 'bool';
 }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/FloatField.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/FloatField.php
@@ -23,7 +23,7 @@ namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
  * @Annotation
  * @deprecated This class will be removed in ODM 2.0
  */
-final class Int extends AbstractField
+final class FloatField extends AbstractField
 {
-    public $type = 'int';
+    public $type = 'float';
 }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/IntField.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/IntField.php
@@ -23,7 +23,7 @@ namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
  * @Annotation
  * @deprecated This class will be removed in ODM 2.0
  */
-final class Bool extends AbstractField
+final class IntField extends AbstractField
 {
-    public $type = 'bool';
+    public $type = 'int';
 }

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/StringField.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/StringField.php
@@ -23,7 +23,7 @@ namespace Doctrine\ODM\MongoDB\Mapping\Annotations;
  * @Annotation
  * @deprecated This class will be removed in ODM 2.0
  */
-final class Float extends AbstractField
+final class StringField extends AbstractField
 {
-    public $type = 'float';
+    public $type = 'string';
 }


### PR DESCRIPTION
Hello,

I renamed the class String, Float, Int and Bool to be compatible with PHP7 (reserved keywords)

There is no code changes to be expected if you already use 

``` php
/** @MongoDB\Field(type="string") */
```

instead of

``` php
/** @MongoDB\String */
```

in the annotations of an entity.

Thanks,

Yoann
